### PR TITLE
Allow custom ports below 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,13 @@ RUN apt-get --auto-remove -y purge ${BUILD_REQUIREMENTS} \
 
 EXPOSE ${STATUS_PORT} ${SERVER_PORT}
 
-USER $USERNAME
 VOLUME ${USER_HOME}/certs
 
-CMD ${USER_HOME}/server/relaysrv \
+CMD iptables -t nat -A PREROUTING -i eth0 -p tcp --dport ${SERVER_PORT} -j REDIRECT --to-port 22067 && \
+    sudo -u $USERNAME ${USER_HOME}/server/relaysrv \
     -keys="${USER_HOME}/certs" \
-    -listen="0.0.0.0:${SERVER_PORT}" \
+    -listen=":22067" \
+    -ext-address ":${SERVER_PORT}" \
     -status-srv="0.0.0.0:${STATUS_PORT}" \
     -debug="${DEBUG}" \
     -global-rate="${RATE_GLOBAL}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV APPUID 1000
 ENV APPGID 1000
 ENV USER_HOME /home/relaysrv
 ENV BUILD_REQUIREMENTS curl openssl
-ENV REQUIREMENTS ca-certificates
+ENV REQUIREMENTS ca-certificates iptables sudo
 ########################################
 
 USER root


### PR DESCRIPTION
Non-root users cannot bind ports below 1000 unless special privileges are granted. I implemented a fix based on what the Syncthing documentation suggests: https://docs.syncthing.net/users/strelaysrv.html#running-on-port-443-as-an-unprivileged-user

The changes were tested locally both with custom ports but also the default 22067 port.