### PR TITLE
enabling basic multi-arch build and push support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: |-
+            linux/arm64
+            linux/amd64
           tags: |
             t4skforce/syncthing-relay:latest
             t4skforce/syncthing-relay:${{ env.RELEASE_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM --platform=$TARGETPLATFORM debian:latest
 ########################################
 #              Settings                #
 ########################################
@@ -39,8 +39,11 @@ ARG REQUIREMENTS="openssl ca-certificates"
 ########################################
 #               Build                  #
 ########################################
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 ARG VERSION="v1.15.0"
-ARG DOWNLOADURL="https://github.com/syncthing/relaysrv/releases/download/v1.15.0/strelaysrv-linux-amd64-v1.15.0.tar.gz"
+ARG DOWNLOAD_URL_PREFIX="https://github.com/syncthing/relaysrv/releases/download"
+ARG BIN_NAME="strelaysrv"
 ARG BUILD_DATE="2021-12-17T13:41:35Z"
 ########################################
 
@@ -57,10 +60,9 @@ RUN apt-get update -qqy \
 
 # install relay
 WORKDIR /tmp/
-RUN curl -Ls ${DOWNLOADURL} --output relaysrv.tar.gz \
-	&& tar -zxf relaysrv.tar.gz \
-	&& rm relaysrv.tar.gz \
-	&& mkdir -p ${USER_HOME}/server ${USER_HOME}/certs \
+COPY download.sh /tmp/download.sh
+RUN ./download.sh "${DOWNLOAD_URL_PREFIX}" "${BIN_NAME}" "${VERSION}" "${TARGETPLATFORM}"
+RUN mkdir -p ${USER_HOME}/server ${USER_HOME}/certs \
 	&& cp /tmp/*relaysrv*/*relaysrv ${USER_HOME}/server/relaysrv \
 	&& chown -R ${USERNAME}:${USERGROUP} ${USER_HOME}
 

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -xe
+
+url_prefix="${1}"
+bin_name="${2}"
+version="${3}"
+arch=$(echo "${4}" | cut -d"/" -f2)
+
+dl_url="${url_prefix}/${version}/${bin_name}-linux-${arch}-${version}.tar.gz"
+
+echo "Downloading \"${dl_url}\"..."
+
+curl -Ls "${dl_url}" --output relaysrv.tar.gz \
+  && tar -zxf relaysrv.tar.gz \
+  && rm relaysrv.tar.gz


### PR DESCRIPTION
heyo, first thanks for building putting this image together!  this is a quick & dirty uplift to support multi-arch builds.  My current needs extend only to linux arm64 & amd64, so that's all I added :)

I have tested the resulting image works on an pi4 running 64bit ubuntu as well as amd64.  Only untested part is the gh action piece :)

Let me know if you want any changes!